### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `ricaun.Revit.Installation` to `1.4.0`.
 ### Build
 - Replace ` ` to `.` in the installation name.
-- Update app name to `ricaun.RevitShell`.
+- Update app name to `ricaun.RevitShell` and folder.
 
 ## [1.0.1] / 2024-05-15
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `ricaun.Revit.Installation` to `1.4.0`.
 ### Build
 - Replace ` ` to `.` in the installation name.
-- Add `ricaun` in the installation name.
+- Update app name to `ricaun.RevitShell`.
 
 ## [1.0.1] / 2024-05-15
 ### Features

--- a/Install/RevitShell.iss
+++ b/Install/RevitShell.iss
@@ -4,11 +4,11 @@
 ; by Luiz Henrique Cassettari 
 
 #define AppId "{75C82D94-C2D8-4F8A-AB17-F98A8BC0E712}"
-#define AppName "RevitShell"
+#define AppName "ricaun.RevitShell"
 #define AppVersion "1.0.0"
 #define AppPublisher "ricaun"
 #define AppComments "Windows Shell Extensions in .NET for Revit files. "
-#define AppFolder "RevitShell"
+#define AppFolder "ricaun.RevitShell"
 #define AppURL "https://github.com/ricaun-io/RevitShell"
 #define AppEmail ""
 
@@ -30,7 +30,7 @@ DefaultDirName="{autopf}\{#AppFolder}\{#AppVersion}"
 DisableWelcomePage=no
 DisableDirPage=no
 DisableProgramGroupPage=yes
-OutputBaseFilename="ricaun.{#AppName}.{#AppVersion}"
+OutputBaseFilename="{#AppName}.{#AppVersion}"
 UninstallDisplayName="{#AppName}"
 
 LicenseFile="..\LICENSE"

--- a/Install/RevitShell.iss
+++ b/Install/RevitShell.iss
@@ -8,7 +8,7 @@
 #define AppVersion "1.0.0"
 #define AppPublisher "ricaun"
 #define AppComments "Windows Shell Extensions in .NET for Revit files. "
-#define AppFolder "ricaun.RevitShell"
+#define AppFolder "ricaun\RevitShell"
 #define AppURL "https://github.com/ricaun-io/RevitShell"
 #define AppEmail ""
 
@@ -57,7 +57,7 @@ Name: {app}; Permissions: users-full
 Name: "en"; MessagesFile: "compiler:Default.isl";
 
 [Files]
-Source: "..\{#AppFolder}\bin\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs signonce
+Source: "..\RevitShell\bin\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs signonce
 
 [Run]
 Filename: "{app}\ServerRegistrationManager.exe"; Parameters: "install ""{app}\RevitShell.dll"" -codebase"


### PR DESCRIPTION
### Features
- Support Revit 2026.
### Updates
- Update `ricaun.Revit.Installation` to `1.4.0`.
### Build
- Replace ` ` to `.` in the installation name.
- Update app name to `ricaun.RevitShell` and folder.